### PR TITLE
Updated the install config function to find the correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A modularised version of [this reddit post](https://www.reddit.com/r/neovim/comm
 
 ```
 {
-  "roobert/fs-string-toggle.nvim",
+  "roobert/f-string-toggle.nvim",
   config = function()
-    require("fs-string-toggle").setup({
+    require("f-string-toggle").setup({
       key_binding = "<leader>f"
     })
   end,


### PR DESCRIPTION
I don't even know if you'll accept a PR @roobert , but I really like this plugin! After getting it installed, it has been super helpful. 

However, the install config doesn't work - it is called `fs-string` when your repo is `f-string`. I got it successfully installed after pointing it at the correct repo and figured I'd help update it for others. 

Side note: shout out to [kbin](https://open-source.social/m/neovim) and [Reddit](https://www.reddit.com/r/neovim) which is where I learned about this plugin! 