### PR TITLE
Replace deprecated `nvim_buf_get_option()` with `nvim_get_option_value()`

### DIFF
--- a/lua/f-string-toggle/init.lua
+++ b/lua/f-string-toggle/init.lua
@@ -4,7 +4,7 @@ local config = require("f-string-toggle.config")
 
 M.toggle_fstring = function()
 	local current_buf = vim.api.nvim_get_current_buf()
-	local filetype = vim.api.nvim_buf_get_option(current_buf, "filetype")
+	local filetype = vim.api.nvim_get_option_value("filetype", { buf = current_buf })
 
 	if filetype ~= "python" then
 		return


### PR DESCRIPTION
`nvim_buf_get_option()` was deprecated in version 0.10.

Thank you!