### PR TITLE
Support filetypes other than Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A modularised version of [this reddit post](https://www.reddit.com/r/neovim/comm
 
 ## Install
 
-```
+```lua
 {
   "roobert/f-string-toggle.nvim",
   config = function()
     require("f-string-toggle").setup({
       key_binding = "<leader>f",
       key_binding_desc = "Toggle f-string"
+      filetypes = { "python" },
     })
   end,
 }

--- a/lua/f-string-toggle/config.lua
+++ b/lua/f-string-toggle/config.lua
@@ -3,6 +3,7 @@ local M = {}
 M.options = {
 	key_binding = "<leader>f",
 	key_binding_desc = "Toggle f-string",
+	filetypes = { "python", "snakemake", "markdown", "org" },
 }
 
 return M

--- a/lua/f-string-toggle/config.lua
+++ b/lua/f-string-toggle/config.lua
@@ -3,7 +3,7 @@ local M = {}
 M.options = {
 	key_binding = "<leader>f",
 	key_binding_desc = "Toggle f-string",
-	filetypes = { "python", "snakemake", "markdown", "org" },
+	filetypes = { "python" },
 }
 
 return M

--- a/lua/f-string-toggle/init.lua
+++ b/lua/f-string-toggle/init.lua
@@ -2,13 +2,11 @@ local M = {}
 
 local config = require("f-string-toggle.config")
 
-local filetypes = { "python", "snakemake", "markdown", "org" }
-
 M.toggle_fstring = function()
 	local current_buf = vim.api.nvim_get_current_buf()
 	local filetype = vim.api.nvim_get_option_value("filetype", { buf = current_buf })
 
-	if not vim.tbl_contains(filetypes, filetype) then
+	if not vim.tbl_contains(config.options.filetypes, filetype) then
 		return
 	end
 

--- a/lua/f-string-toggle/init.lua
+++ b/lua/f-string-toggle/init.lua
@@ -2,11 +2,13 @@ local M = {}
 
 local config = require("f-string-toggle.config")
 
+local filetypes = { "python", "snakemake", "markdown", "org" }
+
 M.toggle_fstring = function()
 	local current_buf = vim.api.nvim_get_current_buf()
 	local filetype = vim.api.nvim_get_option_value("filetype", { buf = current_buf })
 
-	if filetype ~= "python" then
+	if not vim.tbl_contains(filetypes, filetype) then
 		return
 	end
 


### PR DESCRIPTION
I found this plugin useful in markdown code blocks and snakemake files. This PR adds a `filetypes` config option that is set to `{ "python", "snakemake", "markdown", "org" }` by default. Let me know if you think some should be added or removed.

I hesitated making this an option or just hardcoding the supported filetypes. I can revert to the latter if you prefer but I thought having the option would be useful to support more use cases.

Thanks!