### PR TITLE
Allow users to disable default mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,33 @@ A modularised version of [this reddit post](https://www.reddit.com/r/neovim/comm
 }
 ```
 
+## Configure
+
+### Disable default mapping
+
+If you would prefer not to use the default key binding, you can set `key_binding = false` and directly call `toggle_fstring()`. Here is an example with `lazy.nvim`:
+
+```lua
+{
+  "roobert/f-string-toggle.nvim",
+  keys = {
+    { "<leader>fs", function() require("f-string-toggle").toggle_fstring() end, desc = "Toggle f-string" }
+  },
+  config = function()
+    require("f-string-toggle").setup({
+      key_binding = false,
+    })
+  end,
+}
+```
+
+If you want to set the mapping outside `lazy.nvim`, you can use:
+
+```lua
+vim.keymap.set('n', '<leader>f', function() require('f-string-toggle').toggle_fstring() end, { desc = "Toggle f-string" })
+```
+
+
 ## Usage
 
 Within a string press leader-f to toggle if it's an f-string or not.

--- a/lua/f-string-toggle/init.lua
+++ b/lua/f-string-toggle/init.lua
@@ -60,12 +60,14 @@ function M.setup(options)
 		config.options[k] = v
 	end
 
-	vim.api.nvim_set_keymap(
-		"n",
-		config.options["key_binding"],
-		":lua require('f-string-toggle').toggle_fstring()<CR>",
-		{ noremap = true, silent = true, desc = config.options["key_binding_desc"] }
-	)
+  if config.options["key_binding"] then
+    vim.keymap.set(
+      "n",
+      config.options["key_binding"],
+      function() require('f-string-toggle').toggle_fstring() end,
+      { silent = true, desc = config.options["key_binding_desc"] }
+    )
+  end
 end
 
 return M


### PR DESCRIPTION
This just adds an if statement to skip setting the default mapping if `key_binding = false` in the config.

It allows users to set the mapping with `vim.keymap.set()` or `lazy.nvim`. I added some documentation about this in the README.

I think this partially addresses #3, although I think the author of the issue argues that the mapping should only be set externally, and not in `setup`. Personally I also feel that it would be even simpler to remove the default mapping and document a short example of how to set it, but the current state of the PR keeps everything backward compatible. Let me know what you prefer @roobert.

Thanks!